### PR TITLE
Fix derivative of hat functions for different sized intervals

### DIFF
--- a/src/PiecewiseOrthogonalPolynomials.jl
+++ b/src/PiecewiseOrthogonalPolynomials.jl
@@ -236,12 +236,11 @@ end
     # Legendre() \ (D*Weighted(Jacobi(1,1)))
     r = C.points
     N = length(r)
-    v = mortar(Fill.((-convert(T, 2):-2:-∞), N - 1))
-    s = mortar(Fill(convert(T,2) ./ (r[2:end]-r[1:end-1]), ∞))
-    v = s .* v
+    s = one(T) ./ (r[2:end]-r[1:end-1])
+    v = mortar(Fill(T(2) * s, ∞)) .* mortar(Fill.((-convert(T, 2):-2:-∞), N - 1))
     z = Zeros{T}(axes(v))
     H = BlockBroadcastArray(hcat, z, v)
-    M = BlockVcat(Hcat(Ones{T}(N) * (N-1), -Ones{T}(N) * (N-1)), H)
+    M = BlockVcat(Hcat(Ones{T}(N) .* [zero(T); s] , -Ones{T}(N) .* [s; zero(T)] ), H)
     P = ContinuousPolynomial{0}(C)
     P * _BandedBlockBandedMatrix(M', (axes(P, 2), axes(C, 2)), (0, 0), (0, 1))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,7 +70,7 @@ end
 end
 
 @testset "derivative" begin
-    r = range(0,1; length=4)
+    r = [0, 0.2, 0.5, 1]
     C = ContinuousPolynomial{1}(r)
     P = ContinuousPolynomial{0}(r)
     x = axes(C,1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,18 +70,19 @@ end
 end
 
 @testset "derivative" begin
-    r = [0, 0.2, 0.5, 1]
-    C = ContinuousPolynomial{1}(r)
-    P = ContinuousPolynomial{0}(r)
-    x = axes(C,1)
-    D = Derivative(x)
-    A = P\D*C
+    for r in (range(0,1; length=4), [0, 0.2, 0.5, 1])
+        C = ContinuousPolynomial{1}(r)
+        P = ContinuousPolynomial{0}(r)
+        x = axes(C,1)
+        D = Derivative(x)
+        A = P\D*C
 
-    xx = rand(5)
-    c = (x, p) -> ContinuousPolynomial{1, eltype(x)}(r)[x, p]
+        xx = rand(5)
+        c = (x, p) -> ContinuousPolynomial{1, eltype(x)}(r)[x, p]
 
-    for p = 1:30
-        @test derivative.(x->c(x, p), xx) ≈ (P*A)[xx, p]
+        for p = 1:30
+            @test derivative.(x->c(x, p), xx) ≈ (P*A)[xx, p]
+        end
     end
 
 end


### PR DESCRIPTION
I realised that the derivative of the hat functions were giving the wrong conversion values if the elements were different sizes. Here is the fix. 